### PR TITLE
Fix expiry month and year parsing issue

### DIFF
--- a/src/ios/Checkout.swift
+++ b/src/ios/Checkout.swift
@@ -71,7 +71,7 @@ class DictionaryEncoder {
     private let jsonEncoder = JSONEncoder()
     /// Encodes given Encodable value into an array or dictionary
     func encode<T>(_ value: T) throws -> Any where T: Encodable {
-        jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
+
         let jsonData = try jsonEncoder.encode(value)
         return try JSONSerialization.jsonObject(with: jsonData, options: .allowFragments)
     }
@@ -81,7 +81,7 @@ class DictionaryDecoder {
     private let jsonDecoder = JSONDecoder()
     /// Decodes given Decodable type from given array or dictionary
     func decode<T>(_ type: T.Type, from json: Any) throws -> T where T: Decodable {
-        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase;
+
         let jsonData = try JSONSerialization.data(withJSONObject: json, options: [])
         return try jsonDecoder.decode(type, from: jsonData)
     }


### PR DESCRIPTION
Reverting the encoding and decoding strategy since it appears to be already solved in the frames-ios sdk and is now causing parse error issues